### PR TITLE
ログインページと初期登録ページのヘッダーを修正

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -16,39 +16,45 @@ export default function Header() {
       <Link href="/community" className="cursor-pointer px-4 text-2xl text-white">
         UT-Bridge
       </Link>
-      <button
-        type="button"
-        className={`h-full cursor-pointer px-4 text-white text-xl transition-colors duration-200 ${
-          pathname === "/community" ? "bg-focus" : "hover:bg-focus"
-        }`}
-        onClick={() => {
-          router.push("/community");
-        }}
-      >
-        コミュニティ
-      </button>
-      <button
-        type="button"
-        className={`h-full cursor-pointer px-4 text-white text-xl transition-colors duration-200 ${
-          pathname === "/chat" ? "bg-focus" : "hover:bg-focus"
-        }`}
-        onClick={() => {
-          router.push("/chat");
-        }}
-      >
-        チャット
-      </button>
-      <button
-        type="button"
-        className={`h-full cursor-pointer px-4 text-white text-xl transition-colors duration-200 ${
-          pathname === "/settings" ? "bg-focus" : "hover:bg-focus"
-        }`}
-        onClick={() => {
-          router.push("/settings");
-        }}
-      >
-        設定
-      </button>
+      {pathname === "/login" ? (
+        <></>
+      ) : (
+        <>
+          <button
+            type="button"
+            className={`h-full cursor-pointer px-4 text-white text-xl transition-colors duration-200 ${
+              pathname === "/community" ? "bg-focus" : "hover:bg-focus"
+            }`}
+            onClick={() => {
+              router.push("/community");
+            }}
+          >
+            コミュニティ
+          </button>
+          <button
+            type="button"
+            className={`h-full cursor-pointer px-4 text-white text-xl transition-colors duration-200 ${
+              pathname === "/chat" ? "bg-focus" : "hover:bg-focus"
+            }`}
+            onClick={() => {
+              router.push("/chat");
+            }}
+          >
+            チャット
+          </button>
+          <button
+            type="button"
+            className={`h-full cursor-pointer px-4 text-white text-xl transition-colors duration-200 ${
+              pathname === "/settings" ? "bg-focus" : "hover:bg-focus"
+            }`}
+            onClick={() => {
+              router.push("/settings");
+            }}
+          >
+            設定
+          </button>
+        </>
+      )}
     </header>
   );
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
       <Link href="/community" className="cursor-pointer px-4 text-2xl text-white">
         UT-Bridge
       </Link>
-      {pathname === "/login" ? (
+      {pathname === "/login" || pathname === "/registration" ? (
         <></>
       ) : (
         <>


### PR DESCRIPTION
## 解決するissue

close #89 

初期登録画面の細かいuiは #105

## 変更点

<!-- PRで変わったところを簡単に -->

## 動作確認
<img width="1428" alt="スクリーンショット 2025-03-03 16 42 43" src="https://github.com/user-attachments/assets/e1512dd0-1e08-4d6d-8da0-edc12f895660" />
<img width="1428" alt="スクリーンショット 2025-03-03 16 42 51" src="https://github.com/user-attachments/assets/eb38df41-08c2-4056-9b7e-d09d95702c09" />
<img width="1429" alt="スクリーンショット 2025-03-03 18 09 21" src="https://github.com/user-attachments/assets/c1a22e24-014e-4fbb-8937-1abb46c0181e" />



- [x] した

## レビュアーへの補足


<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
