### PR TITLE
チャットの更新時・アクセス時に最下部へスクロール

### DIFF
--- a/web/src/app/[locale]/(auth)/chat/[id]/page.tsx
+++ b/web/src/app/[locale]/(auth)/chat/[id]/page.tsx
@@ -10,7 +10,7 @@ import { Link } from "@/i18n/navigation";
 import { assert } from "@/lib";
 import { use } from "@/react/useData";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AiOutlineLeft, AiOutlineSend } from "react-icons/ai";
 
 export default function Page() {
@@ -181,6 +181,13 @@ function MessageList({
     target.scrollIntoView(false);
   }
 
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messages;
+    bottomRef.current?.scrollIntoView({ behavior: "auto" });
+  }, [messages]);
+
   return (
     <ul className="mx-3 mt-[56px] mb-[76px] grow overflow-y-scroll sm:pb-0" id="scroll-bottom">
       {messages.map((m) => (
@@ -202,6 +209,7 @@ function MessageList({
           </div>
         </li>
       ))}
+      <div ref={bottomRef} />
     </ul>
   );
 }


### PR DESCRIPTION
## 解決するissue

close #274 

## 変更点

<!-- PRで変わったところを簡単に -->
useRefで、チャットの後ろの要素（ダミー）を自動参照するようにした。

## 動作確認

- [x] した

## レビュアーへの補足


<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
