### PR TITLE
トップページのスマホの画像が大画面でも縦に引き伸ばされないように修正

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -6,6 +6,8 @@ import { Link } from "@/i18n/navigation.ts";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
+import samplePicEn from "../../../public/app_sample_en.png";
+import samplePicJa from "../../../public/app_sample_ja.png";
 
 export default function LandingPage() {
   const t = useTranslations();
@@ -14,13 +16,9 @@ export default function LandingPage() {
     <>
       <Header />
       <main className="flex w-full flex-grow flex-col-reverse justify-center bg-white pt-10 xl:flex-row">
-        <Image
-          src={pathname.startsWith("/ja") ? "/app_sample_ja.png" : "/app_sample_en.png"}
-          alt="app sample image"
-          width={500}
-          height={100}
-          className="m-auto xl:m-0"
-        />
+        <div className="m-auto flex max-w-[500px] flex-col items-center justify-center xl:m-0">
+          <Image src={pathname.startsWith("/ja") ? samplePicJa : samplePicEn} alt="app sample image" />
+        </div>
         <div className="my-10 mr-5 flex flex-col items-center justify-center xl:my-0 xl:mr-20">
           <div className="flex flex-col items-start">
             <p className="-translate-x-5 xl:-translate-x-20 my-1 mt-5 bg-tBlue px-10 py-1 text-[min(10vw,48px)] text-white shadow-md xl:my-2 xl:mt-2 xl:py-2 xl:text-7xl xl:shadow-2xl">


### PR DESCRIPTION
## 解決するissue

close #299 

## 変更点

トップページのスマホの画像が大画面でも縦に引き伸ばされないように修正

## 動作確認

- [x] した

https://github.com/user-attachments/assets/4b80e88d-20fd-4eaa-9707-a952899c11d9

## レビュアーへの補足

特になし。FF 外から失礼します

<!-- レビューリクエスト後は、Slackでもメンションしてお願いすることを推奨します。 -->
